### PR TITLE
chore: update NotificationFeedItem DTO with isArchived support

### DIFF
--- a/models/components/notificationfeeditemdto.go
+++ b/models/components/notificationfeeditemdto.go
@@ -83,7 +83,7 @@ type NotificationFeedItemDto struct {
 	// Indicates whether the notification has been seen by the subscriber.
 	Seen bool `json:"seen"`
 	// Indicates whether the notification has been archived.
-	IsArchived *bool `json:"isArchived,omitempty"`
+	IsArchived *bool `json:"archived,omitempty"`
 	// Device tokens for push notifications, if applicable.
 	DeviceTokens []string `json:"deviceTokens,omitempty"`
 	// Call-to-action information associated with the notification.

--- a/models/components/notificationfeeditemdto.go
+++ b/models/components/notificationfeeditemdto.go
@@ -82,6 +82,8 @@ type NotificationFeedItemDto struct {
 	Read bool `json:"read"`
 	// Indicates whether the notification has been seen by the subscriber.
 	Seen bool `json:"seen"`
+	// Indicates whether the notification has been archived.
+	IsArchived bool `json:"isArchived"`
 	// Device tokens for push notifications, if applicable.
 	DeviceTokens []string `json:"deviceTokens,omitempty"`
 	// Call-to-action information associated with the notification.
@@ -103,7 +105,7 @@ func (n NotificationFeedItemDto) MarshalJSON() ([]byte, error) {
 }
 
 func (n *NotificationFeedItemDto) UnmarshalJSON(data []byte) error {
-	if err := utils.UnmarshalJSON(data, &n, "", false, []string{"_id", "_templateId", "_environmentId", "_organizationId", "_notificationId", "_subscriberId", "_jobId", "transactionId", "content", "channel", "read", "seen", "cta", "status"}); err != nil {
+	if err := utils.UnmarshalJSON(data, &n, "", false, []string{"_id", "_templateId", "_environmentId", "_organizationId", "_notificationId", "_subscriberId", "_jobId", "transactionId", "content", "channel", "read", "seen", "isArchived", "cta", "status"}); err != nil {
 		return err
 	}
 	return nil
@@ -254,6 +256,13 @@ func (n *NotificationFeedItemDto) GetSeen() bool {
 		return false
 	}
 	return n.Seen
+}
+
+func (n *NotificationFeedItemDto) GetIsArchived() bool {
+	if n == nil {
+		return false
+	}
+	return n.IsArchived
 }
 
 func (n *NotificationFeedItemDto) GetDeviceTokens() []string {

--- a/models/components/notificationfeeditemdto.go
+++ b/models/components/notificationfeeditemdto.go
@@ -83,7 +83,7 @@ type NotificationFeedItemDto struct {
 	// Indicates whether the notification has been seen by the subscriber.
 	Seen bool `json:"seen"`
 	// Indicates whether the notification has been archived.
-	IsArchived bool `json:"isArchived"`
+	IsArchived *bool `json:"isArchived,omitempty"`
 	// Device tokens for push notifications, if applicable.
 	DeviceTokens []string `json:"deviceTokens,omitempty"`
 	// Call-to-action information associated with the notification.
@@ -105,7 +105,7 @@ func (n NotificationFeedItemDto) MarshalJSON() ([]byte, error) {
 }
 
 func (n *NotificationFeedItemDto) UnmarshalJSON(data []byte) error {
-	if err := utils.UnmarshalJSON(data, &n, "", false, []string{"_id", "_templateId", "_environmentId", "_organizationId", "_notificationId", "_subscriberId", "_jobId", "transactionId", "content", "channel", "read", "seen", "isArchived", "cta", "status"}); err != nil {
+	if err := utils.UnmarshalJSON(data, &n, "", false, []string{"_id", "_templateId", "_environmentId", "_organizationId", "_notificationId", "_subscriberId", "_jobId", "transactionId", "content", "channel", "read", "seen", "cta", "status"}); err != nil {
 		return err
 	}
 	return nil
@@ -258,9 +258,9 @@ func (n *NotificationFeedItemDto) GetSeen() bool {
 	return n.Seen
 }
 
-func (n *NotificationFeedItemDto) GetIsArchived() bool {
+func (n *NotificationFeedItemDto) GetIsArchived() *bool {
 	if n == nil {
-		return false
+		return nil
 	}
 	return n.IsArchived
 }


### PR DESCRIPTION
**Summary**

Adds support for the isArchived field on NotificationFeedItem DTOs so the Go SDK stays in sync with the API response.

**Motivation**

The Novu API exposes an isArchived property on notification feed items, but the Go SDK did not surface it.
This caused consumers to lose archive state information when working with notification feeds.

**Changes**

- Added isArchived field to NotificationFeedItem DTO

- Updated related mappings / structs where applicable

- No breaking changes

**Impact**

✅ Backward compatible

✅ Improves feature parity with Novu API

❌ No behavior changes outside data exposure

**Testing**

- Manually verified struct unmarshalling from API response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added archiving capability for notification feed items, enabling users to organize and manage their notifications more effectively by marking items as archived.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->